### PR TITLE
implemented primitive battle queue

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,13 +1,19 @@
+/* client/src/index.js */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import 'semantic-ui-css/semantic.min.css';
 import App from './App';
-
 /**
  * At the moment you can touch this to test the connection
  */
 import openSocket from 'socket.io-client';
-const  socket = openSocket('http://localhost:5000');
 
-ReactDOM.render(<App />, document.getElementById('root'));
+let socket = openSocket('http://localhost:5000');
+socket.on('battle id', function (id) {
+    console.log(`entering battle ${id}`);
+
+});
+
+ReactDOM.render(<App/>, document.getElementById('root'));

--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+/* server.js */
+
 const port = process.env.PORT || 5000;
 const io = require('socket.io')();
 
@@ -15,11 +17,45 @@ app.get('/express_backend', (req, res) => {
 });
 */
 const connections = new Map();
+const battles = [];
+
+function getFirstWaitingBattle(battles) {
+    let i = 0;
+    let result = null;
+    battles.forEach(battle => {
+        let room = io.sockets.adapter.rooms[battle];
+        let clients = (typeof room !== 'undefined' ? room.sockets : undefined);
+        let numPlayers = (typeof clients !== 'undefined') ? Object.keys(clients).length : 0;
+        console.log(`${battle} has ${numPlayers} players`);
+        if (!result && (numPlayers < 2 || !numPlayers)) {
+            console.log(`found battle${i} waiting`);
+            result = battle;
+        } else {
+            i++;
+        }
+    });
+    return result;
+}
 
 io.on('connection', function (c) {
 
     connections.set(c, c);
     console.log('connected ', c.id);
+
+    let firstWaitingBattle = getFirstWaitingBattle(battles);
+    let battleToJoin = firstWaitingBattle;
+    console.log(`firstWaitingBattle = ${firstWaitingBattle}`);
+    if (!battles.length || !firstWaitingBattle) {
+        battleToJoin = `battle${battles.length}`;
+        console.log(`creating battle${battles.length}`);
+        battles.push(battleToJoin);
+    }
+    io.to(c.id).emit('battle id', battleToJoin);
+    c.join(battleToJoin);
+    io.in(battleToJoin).clients((err, clients) => {
+        console.log(clients);
+    });
+
 
     c.once('disconnect', function () {
         connections.delete(c);
@@ -30,3 +66,4 @@ io.on('connection', function (c) {
 
 io.listen(port);
 console.log('socket.io listening on ', port);
+

--- a/server.js
+++ b/server.js
@@ -1,8 +1,5 @@
 /* server.js */
 
-const port = process.env.PORT || 5000;
-const io = require('socket.io')();
-
 /*
 const express = require('express');
 const app = express();
@@ -16,52 +13,47 @@ app.get('/express_backend', (req, res) => {
   console.log('got called!');
 });
 */
+
+const port = process.env.PORT || 5000;
+const io = require('socket.io')();
 const connections = new Map();
 const battles = [];
 
-function getFirstWaitingBattle(battles) {
-    let i = 0;
-    let result = null;
-    battles.forEach(battle => {
-        let room = io.sockets.adapter.rooms[battle];
-        let clients = (typeof room !== 'undefined' ? room.sockets : undefined);
-        let numPlayers = (typeof clients !== 'undefined') ? Object.keys(clients).length : 0;
-        console.log(`${battle} has ${numPlayers} players`);
-        if (!result && (numPlayers < 2 || !numPlayers)) {
-            console.log(`found battle${i} waiting`);
-            result = battle;
-        } else {
-            i++;
-        }
-    });
-    return result;
+function isBattleWaiting(battle) {
+    const room = io.sockets.adapter.rooms[battle];
+    const clients = (typeof room !== 'undefined' ? room.sockets : undefined);
+    const numPlayers = (typeof clients !== 'undefined') ? Object.keys(clients).length : 0;
+    console.log(`${battle} has ${numPlayers} players`);
+    return (numPlayers < 2);
 }
 
-io.on('connection', function (c) {
+io.on('connection', function (client) {
+    connections.set(client, client);
+    console.log('connected ', client.id);
 
-    connections.set(c, c);
-    console.log('connected ', c.id);
-
-    let firstWaitingBattle = getFirstWaitingBattle(battles);
+    const waitingBattles = battles.filter(isBattleWaiting);
+    let firstWaitingBattle = (waitingBattles.length ? waitingBattles[0] : null);
     let battleToJoin = firstWaitingBattle;
+
     console.log(`firstWaitingBattle = ${firstWaitingBattle}`);
+
     if (!battles.length || !firstWaitingBattle) {
         battleToJoin = `battle${battles.length}`;
         console.log(`creating battle${battles.length}`);
         battles.push(battleToJoin);
     }
-    io.to(c.id).emit('battle id', battleToJoin);
-    c.join(battleToJoin);
-    io.in(battleToJoin).clients((err, clients) => {
-        console.log(clients);
+
+    client.join(battleToJoin);
+
+    io.to(client.id).emit('battle id', battleToJoin);
+    io.in(battleToJoin).clients((err, battlePlayers) => {
+        console.log(battlePlayers);
     });
 
-
-    c.once('disconnect', function () {
-        connections.delete(c);
-        console.log('disconnected ', c.id);
+    client.once('disconnect', function () {
+        connections.delete(client);
+        console.log('disconnected ', client.id);
     });
-
 });
 
 io.listen(port);


### PR DESCRIPTION
Implements a simple battle queue using socket.io rooms. Every time a user connects to the server, it searches for the first battle with less than two players and puts the player there. If there are no battles waiting for players, the server creates a new one and puts the player there.